### PR TITLE
fix bug where EntityGetEndpoint would hang if items/orderedItems was …

### DIFF
--- a/packages/activitypub-core-endpoints/src/entity/index.ts
+++ b/packages/activitypub-core-endpoints/src/entity/index.ts
@@ -142,8 +142,8 @@ export class EntityGetEndpoint {
     const typeFilter = query.has('type') ? query.get('type').split(',') : [];
     const sort = query.get('sort');
     const limit = query.has('limit') ? Number(query.get('limit')) : ITEMS_PER_COLLECTION_PAGE;
-    const items = entity[isOrderedCollection ? 'orderedItems' : 'items']
-    const expandedItems = await Promise.all((Array.isArray(items) ? items : []).map(async (id: URL) => {
+    const entityItems = entity[isOrderedCollection ? 'orderedItems' : 'items']
+    const expandedItems = await Promise.all((Array.isArray(entityItems) ? entityItems : []).map(async (id: URL) => {
       return await this.adapters.db.queryById(id);
     }));
     const filteredItems = typeFilter.length ? expandedItems.filter(({ type }) => typeFilter.includes(type)) : expandedItems;

--- a/packages/activitypub-core-endpoints/src/entity/index.ts
+++ b/packages/activitypub-core-endpoints/src/entity/index.ts
@@ -142,7 +142,8 @@ export class EntityGetEndpoint {
     const typeFilter = query.has('type') ? query.get('type').split(',') : [];
     const sort = query.get('sort');
     const limit = query.has('limit') ? Number(query.get('limit')) : ITEMS_PER_COLLECTION_PAGE;
-    const expandedItems = await Promise.all(entity[isOrderedCollection ? 'orderedItems' : 'items'].map(async (id: URL) => {
+    const items = entity[isOrderedCollection ? 'orderedItems' : 'items']
+    const expandedItems = await Promise.all((Array.isArray(items) ? items : []).map(async (id: URL) => {
       return await this.adapters.db.queryById(id);
     }));
     const filteredItems = typeFilter.length ? expandedItems.filter(({ type }) => typeFilter.includes(type)) : expandedItems;


### PR DESCRIPTION
…not an array

as2 allows items/orderedItems to be a Link object, not just an array, so this adds a check on the value before mapping over it. Without this, a non-array value would lead to an uncaught exception.

related, activitypub-core-server-express should probably catch unexpected exceptions in the endpoint `respond` methods and pass the error to express's `next(err)` callback. without that, express will hang on uncaught errors because `res.end()` is never called